### PR TITLE
fix: resolve CI test failures

### DIFF
--- a/internal/gateway/service_test.go
+++ b/internal/gateway/service_test.go
@@ -86,6 +86,7 @@ func TestMiddlewareChain(t *testing.T) {
 	// Test that request passes through middleware chain
 	req := httptest.NewRequest("POST", "/test", nil)
 	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
 	
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
@@ -133,6 +134,7 @@ func TestRateLimiterIntegration(t *testing.T) {
 	// First request should pass
 	req1 := httptest.NewRequest("POST", "/test", nil)
 	req1.Header.Set("Authorization", "Bearer test-key")
+	req1.Header.Set("Content-Type", "application/json")
 	
 	rr1 := httptest.NewRecorder()
 	handler.ServeHTTP(rr1, req1)
@@ -144,6 +146,7 @@ func TestRateLimiterIntegration(t *testing.T) {
 	// Second request should be rate limited
 	req2 := httptest.NewRequest("POST", "/test", nil)
 	req2.Header.Set("Authorization", "Bearer test-key")
+	req2.Header.Set("Content-Type", "application/json")
 	
 	rr2 := httptest.NewRecorder()
 	handler.ServeHTTP(rr2, req2)


### PR DESCRIPTION
## Summary
- Fix metrics collector tests to match new security behavior
- Add required Content-Type headers to gateway tests  
- Ensure CI checks pass on main branch

## Details
The CI was failing due to tests not being updated after security improvements were made:
1. Empty API keys are now sanitized to 'unknown' instead of remaining empty
2. Negative token counts are normalized to 0
3. Very long strings are truncated to 255 characters for security
4. POST/PUT/PATCH requests now require Content-Type headers

## Testing
- Metrics collector edge case tests: Fixed to expect sanitized values
- Gateway service middleware tests: Added required Content-Type headers
- All affected tests now pass locally

## Checklist
- [x] All tests pass
- [x] Code follows existing patterns
- [x] Only test fixes, no production code changes